### PR TITLE
feat: add usdc to mainnet assetlist

### DIFF
--- a/xion/assetlist.json
+++ b/xion/assetlist.json
@@ -9,16 +9,12 @@
         {
           "denom": "uxion",
           "exponent": 0,
-          "aliases": [
-            "microxion"
-          ]
+          "aliases": ["microxion"]
         },
         {
           "denom": "XION",
           "exponent": 6,
-          "aliases": [
-            "xion"
-          ]
+          "aliases": ["xion"]
         }
       ],
       "base": "uxion",
@@ -38,6 +34,57 @@
       "socials": {
         "website": "https://xion.burnt.com/",
         "twitter": "https://twitter.com/burnt_xion"
+      }
+    },
+    {
+      "denom_units": [
+        {
+          "denom": "ibc/F082B65C88E4B6D5EF1DB243CDA1D331D002759E938A0F5CD3FFDC5D53B3E349",
+          "exponent": 0,
+          "aliases": ["uusdc"]
+        },
+        {
+          "denom": "usdc",
+          "exponent": 6
+        }
+      ],
+      "type_asset": "ics20",
+      "base": "ibc/F082B65C88E4B6D5EF1DB243CDA1D331D002759E938A0F5CD3FFDC5D53B3E349",
+      "name": "Noble USDC Token",
+      "display": "usdc",
+      "symbol": "USDC",
+      "coingecko_id": "usd-coin",
+      "traces": [
+        {
+          "type": "ibc",
+          "counterparty": {
+            "chain_name": "noble",
+            "base_denom": "uusdc",
+            "channel_id": "channel-113"
+          },
+          "chain": {
+            "channel_id": "channel-2",
+            "path": "transfer/channel-2/uusdc"
+          }
+        }
+      ],
+      "images": [
+        {
+          "image_sync": {
+            "chain_name": "noble",
+            "base_denom": "uusdc"
+          },
+          "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.svg",
+          "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.png",
+          "theme": {
+            "circle": true,
+            "primary_color_hex": "#2775CA"
+          }
+        }
+      ],
+      "logo_URIs": {
+        "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.png",
+        "svg": "https://raw.githubusercontent.com/cosmos/chain-registry/master/_non-cosmos/ethereum/images/usdc.svg"
       }
     }
   ]


### PR DESCRIPTION
# Add USDC to mainnet asset list
This PR adds the canonical USDC to the assetlist.

## Tasks
- [x] add usdc asset information to assetlist

## Verify
- https://api.xion-mainnet-1.burnt.com/cosmos/bank/v1beta1/denoms_metadata
- https://api.xion-mainnet-1.burnt.com/ibc/apps/transfer/v1/denom_traces
- https://api.xion-mainnet-1.burnt.com/ibc/core/channel/v1/channels/channel-2/ports/transfer
- https://api.xion-mainnet-1.burnt.com/ibc/core/connection/v1/connections/connection-2