### PR TITLE
Update assetlist.json

### DIFF
--- a/testnets/xiontestnet/assetlist.json
+++ b/testnets/xiontestnet/assetlist.json
@@ -32,7 +32,8 @@
           "png": "https://raw.githubusercontent.com/cosmos/chain-registry/master/xion/images/burnt-round.png"
         }
       ],
-      "type_asset": "sdk.coin"
+      "type_asset": "sdk.coin",
+      "coingecko_id": "xion-2"
     },
     {
       "denom_units": [


### PR DESCRIPTION
I we aren't getting the xion token price on settings.testnet.burnt.com because we don't have the `coingecko_id` on the asset