### PR TITLE
Update Xion mainnet to v21.0.1

### DIFF
--- a/xion/chain.json
+++ b/xion/chain.json
@@ -42,33 +42,33 @@
   },
   "codebase": {
     "git_repo": "https://github.com/burnt-labs/xion",
-    "tag": "v20.0.0",
-    "recommended_version": "v20.0.0",
+    "tag": "v21.0.1",
+    "recommended_version": "v21.0.1",
     "language": {
       "type": "go",
-      "version": "v1.23"
+      "version": "v1.24"
     },
     "binaries": {
-      "darwin/amd64": "https://github.com/burnt-labs/xion/releases/download/v20.0.0/xiond_20.0.0_darwin_amd64.tar.gz?checksum=sha256:7476525f27194809a45e920bc6f7e934e64fdc58ab29007fe1f502c6cfc10265",
-      "darwin/arm64": "https://github.com/burnt-labs/xion/releases/download/v20.0.0/xiond_20.0.0_darwin_arm64.tar.gz?checksum=sha256:75ed3db62375fe0acddf72f72c2a9f7d4a70ddba2d4480bc08032caccd09a8eb",
-      "linux/amd64": "https://github.com/burnt-labs/xion/releases/download/v20.0.0/xiond_20.0.0_linux_amd64.tar.gz?checksum=sha256:a7a63a81e6a8095aa532e58f79b98164a7fbdffd0d0f6c98250880dc1c061a0b",
-      "linux/arm64": "https://github.com/burnt-labs/xion/releases/download/v20.0.0/xiond_20.0.0_linux_arm64.tar.gz?checksum=sha256:4c452a48078687b45b95710ccbe506b0e4cb186329b0bac243d3721a624a1001"
+      "darwin/amd64": "https://github.com/burnt-labs/xion/releases/download/v21.0.1/xiond_21.0.1_darwin_amd64.tar.gz?checksum=sha256:22aa1231d284db86b1f44df4a814e8520ff4f6d1d9eaf21dad8079b1b4f6b4ef",
+      "darwin/arm64": "https://github.com/burnt-labs/xion/releases/download/v21.0.1/xiond_21.0.1_darwin_arm64.tar.gz?checksum=sha256:0687ba93ed57c2658b54f217b53c20dca19491487898b782baeb20ab55d87cb6",
+      "linux/amd64": "https://github.com/burnt-labs/xion/releases/download/v21.0.1/xiond_21.0.1_linux_amd64.tar.gz?checksum=sha256:22872984ffb13cef3a79fd7ee923014835f5b17b69952e4fd86a5bf053bd49d9",
+      "linux/arm64": "https://github.com/burnt-labs/xion/releases/download/v21.0.1/xiond_21.0.1_linux_arm64.tar.gz?checksum=sha256:0ffb44d064e8adc7bca8d883da8f168a6e19fd2e265cfdb6d2224adcdeb6b663"
     },
     "sdk": {
       "type": "cosmos",
-      "version": "v0.53.3"
+      "version": "v0.53.4"
     },
     "consensus": {
       "type": "cometbft",
-      "version": "v0.38.17"
+      "version": "v0.38.19"
     },
     "cosmwasm": {
-      "version": "v0.54.0",
+      "version": "v0.61.2",
       "enabled": true
     },
     "ibc": {
       "type": "go",
-      "version": "v8.7.0"
+      "version": "v10.3.0"
     },
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/burnt-labs/xion-mainnet-1/main/config/genesis.json"

--- a/xion/versions.json
+++ b/xion/versions.json
@@ -404,6 +404,43 @@
                 "type": "go",
                 "version": "v8.7.0"
             }
+        },
+        {
+            "name": "v21",
+            "tag": "v21.0.1",
+            "recommended_version": "v21.0.1",
+            "compatible_versions": [
+                "v21.0.0",
+                "v21.0.1"
+            ],
+            "height": 12690000,
+            "proposal": 47,
+            "language": {
+                "type": "go",
+                "version": "v1.24"
+            },
+            "binaries": {
+                "darwin/amd64": "https://github.com/burnt-labs/xion/releases/download/v21.0.1/xiond_21.0.1_darwin_amd64.tar.gz?checksum=sha256:22aa1231d284db86b1f44df4a814e8520ff4f6d1d9eaf21dad8079b1b4f6b4ef",
+                "darwin/arm64": "https://github.com/burnt-labs/xion/releases/download/v21.0.1/xiond_21.0.1_darwin_arm64.tar.gz?checksum=sha256:0687ba93ed57c2658b54f217b53c20dca19491487898b782baeb20ab55d87cb6",
+                "linux/amd64": "https://github.com/burnt-labs/xion/releases/download/v21.0.1/xiond_21.0.1_linux_amd64.tar.gz?checksum=sha256:22872984ffb13cef3a79fd7ee923014835f5b17b69952e4fd86a5bf053bd49d9",
+                "linux/arm64": "https://github.com/burnt-labs/xion/releases/download/v21.0.1/xiond_21.0.1_linux_arm64.tar.gz?checksum=sha256:0ffb44d064e8adc7bca8d883da8f168a6e19fd2e265cfdb6d2224adcdeb6b663"
+            },
+            "sdk": {
+                "type": "cosmos",
+                "version": "v0.53.4"
+            },
+            "consensus": {
+                "type": "cometbft",
+                "version": "v0.38.19"
+            },
+            "cosmwasm": {
+                "version": "v0.61.2",
+                "enabled": true
+            },
+            "ibc": {
+                "type": "go",
+                "version": "v10.3.0"
+            }
         }
     ]
 }


### PR DESCRIPTION
- Add v21.0.1 to versions.json (proposal #47, height 12690000)
- Update chain.json recommended version to v21.0.1
- Update dependencies: Cosmos SDK v0.53.4, CometBFT v0.38.19, CosmWasm v0.61.2, IBC v10.3.0