### PR TITLE
chore: backfill all missing versions for mainnet and testnet

### DIFF
--- a/testnets/xiontestnet2/chain.json
+++ b/testnets/xiontestnet2/chain.json
@@ -42,39 +42,39 @@
   },
   "codebase": {
     "git_repo": "https://github.com/burnt-labs/xion",
-    "tag": "v20.0.0",
-    "recommended_version": "v20.0.0",
+    "tag": "v29.0.0-rc1",
+    "recommended_version": "v29.0.0-rc1",
     "language": {
       "type": "go",
-      "version": "v1.23"
+      "version": "v1.25"
     },
     "binaries": {
-      "darwin/amd64": "https://github.com/burnt-labs/xion/releases/download/v20.0.0/xiond_20.0.0_darwin_amd64.tar.gz?checksum=sha256:7476525f27194809a45e920bc6f7e934e64fdc58ab29007fe1f502c6cfc10265",
-      "darwin/arm64": "https://github.com/burnt-labs/xion/releases/download/v20.0.0/xiond_20.0.0_darwin_arm64.tar.gz?checksum=sha256:75ed3db62375fe0acddf72f72c2a9f7d4a70ddba2d4480bc08032caccd09a8eb",
-      "linux/amd64": "https://github.com/burnt-labs/xion/releases/download/v20.0.0/xiond_20.0.0_linux_amd64.tar.gz?checksum=sha256:a7a63a81e6a8095aa532e58f79b98164a7fbdffd0d0f6c98250880dc1c061a0b",
-      "linux/arm64": "https://github.com/burnt-labs/xion/releases/download/v20.0.0/xiond_20.0.0_linux_arm64.tar.gz?checksum=sha256:4c452a48078687b45b95710ccbe506b0e4cb186329b0bac243d3721a624a1001"
+      "darwin/amd64": "https://github.com/burnt-labs/xion/releases/download/v29.0.0-rc1/xiond_29.0.0-rc1_darwin_amd64.tar.gz?checksum=sha256:52fb0e7bb4c65a2170b8eb2ae94d9489251014ab33379569437802b15b5dc6ff",
+      "darwin/arm64": "https://github.com/burnt-labs/xion/releases/download/v29.0.0-rc1/xiond_29.0.0-rc1_darwin_arm64.tar.gz?checksum=sha256:6865a82aa1b8a7b4245fbe4d98e227d6561d9c372472f4d9b09dcadd20c25948",
+      "linux/amd64": "https://github.com/burnt-labs/xion/releases/download/v29.0.0-rc1/xiond_29.0.0-rc1_linux_amd64.tar.gz?checksum=sha256:63f2a48d8664acb3db1d12a11780da36537575c4e8678fb2e0ab6c0a64dfa4af",
+      "linux/arm64": "https://github.com/burnt-labs/xion/releases/download/v29.0.0-rc1/xiond_29.0.0-rc1_linux_arm64.tar.gz?checksum=sha256:76cfb7f8356e0feb111d3b4feeaef7cdf10ff95cc9b7a28329660a3a92051e41"
     },
     "sdk": {
       "type": "cosmos",
-      "version": "v0.53.3"
+      "version": "v0.53.6"
     },
     "consensus": {
       "type": "cometbft",
-      "version": "v0.38.17"
+      "version": "v0.38.21"
     },
     "cosmwasm": {
-      "version": "v0.54.0",
+      "version": "v0.61.10",
       "enabled": true
     },
     "ibc": {
       "type": "go",
-      "version": "v8.7.0"
+      "version": "v10.5.0"
     },
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/burnt-labs/xion-testnet-2/main/config/genesis.json"
     },
     "compatible_versions": [
-      "v20.0.0"
+      "v29.0.0-rc1"
     ]
   },
   "peers": {
@@ -82,7 +82,7 @@
       {
         "id": "20e1000e88125698264454a884812746c2eb4807",
         "address": "testnet-seeds.lavenderfive.com:22356",
-        "provider": "Lavender.Five Nodes 🐝"
+        "provider": "Lavender.Five Nodes \ud83d\udc1d"
       },
       {
         "id": "ade4d8bc8cbe014af6ebdf3cb7b1e9ad36f412c0",
@@ -127,11 +127,11 @@
     "rpc": [
       {
         "address": "https://rpc.xion-testnet-2.burnt.com:443",
-        "provider": "🔥BurntLabs🔥"
+        "provider": "\ud83d\udd25BurntLabs\ud83d\udd25"
       },
       {
         "address": "https://testnet-2-rpc.xion-api.com:443",
-        "provider": "Lavender.Five Nodes 🐝"
+        "provider": "Lavender.Five Nodes \ud83d\udc1d"
       },
       {
         "address": "https://xion-testnet-rpc.polkachu.com:443",
@@ -145,11 +145,11 @@
     "rest": [
       {
         "address": "https://api.xion-testnet-2.burnt.com",
-        "provider": "🔥BurntLabs🔥"
+        "provider": "\ud83d\udd25BurntLabs\ud83d\udd25"
       },
       {
         "address": "https://testnet-2-api.xion-api.com",
-        "provider": "Lavender.Five Nodes 🐝"
+        "provider": "Lavender.Five Nodes \ud83d\udc1d"
       },
       {
         "address": "https://xion-testnet-api.polkachu.com",
@@ -163,11 +163,11 @@
     "grpc": [
       {
         "address": "grpc.xion-testnet-2.burnt.com:443",
-        "provider": "🔥BurntLabs🔥"
+        "provider": "\ud83d\udd25BurntLabs\ud83d\udd25"
       },
       {
         "address": "testnet-2-grpc.xion-api.com:443",
-        "provider": "Lavender.Five Nodes 🐝"
+        "provider": "Lavender.Five Nodes \ud83d\udc1d"
       },
       {
         "address": "xion-testnet-grpc.polkachu.com:22390",

--- a/testnets/xiontestnet2/versions.json
+++ b/testnets/xiontestnet2/versions.json
@@ -194,8 +194,8 @@
         "v19.0.1",
         "v19.0.2"
       ],
-      "height": 7420000,
-      "proposal": 37,
+      "height": 4050000,
+      "proposal": 23,
       "language": {
         "type": "go",
         "version": "v1.23"
@@ -258,6 +258,319 @@
       "compatible_versions": [
         "v20.0.0"
       ]
+    },
+    {
+      "name": "v21",
+      "tag": "v21.0.1",
+      "recommended_version": "v21.0.1",
+      "compatible_versions": [
+        "v21.0.0",
+        "v21.0.1"
+      ],
+      "height": 6785000,
+      "proposal": 37,
+      "language": {
+        "type": "go",
+        "version": "v1.24"
+      },
+      "binaries": {
+        "darwin/amd64": "https://github.com/burnt-labs/xion/releases/download/v21.0.1/xiond_21.0.1_darwin_amd64.tar.gz?checksum=sha256:22aa1231d284db86b1f44df4a814e8520ff4f6d1d9eaf21dad8079b1b4f6b4ef",
+        "darwin/arm64": "https://github.com/burnt-labs/xion/releases/download/v21.0.1/xiond_21.0.1_darwin_arm64.tar.gz?checksum=sha256:0687ba93ed57c2658b54f217b53c20dca19491487898b782baeb20ab55d87cb6",
+        "linux/amd64": "https://github.com/burnt-labs/xion/releases/download/v21.0.1/xiond_21.0.1_linux_amd64.tar.gz?checksum=sha256:22872984ffb13cef3a79fd7ee923014835f5b17b69952e4fd86a5bf053bd49d9",
+        "linux/arm64": "https://github.com/burnt-labs/xion/releases/download/v21.0.1/xiond_21.0.1_linux_arm64.tar.gz?checksum=sha256:0ffb44d064e8adc7bca8d883da8f168a6e19fd2e265cfdb6d2224adcdeb6b663"
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "v0.53.4"
+      },
+      "consensus": {
+        "type": "cometbft",
+        "version": "v0.38.19"
+      },
+      "cosmwasm": {
+        "version": "v0.61.2",
+        "enabled": true
+      },
+      "ibc": {
+        "type": "go",
+        "version": "v10.3.0"
+      }
+    },
+    {
+      "name": "v22",
+      "tag": "v22.0.0",
+      "recommended_version": "v22.0.0",
+      "height": 9300000,
+      "proposal": 42,
+      "language": {
+        "type": "go",
+        "version": "v1.25"
+      },
+      "binaries": {
+        "darwin/amd64": "https://github.com/burnt-labs/xion/releases/download/v22.0.0/xiond_22.0.0_darwin_amd64.tar.gz?checksum=sha256:7680342309fcb748d730b69cda086fa99e25717d9f7ea40606c43e701a81180d",
+        "darwin/arm64": "https://github.com/burnt-labs/xion/releases/download/v22.0.0/xiond_22.0.0_darwin_arm64.tar.gz?checksum=sha256:dba9e7e5ed337e7166ff0c8e41be6e8f68e90cacca3ff6421c355c748bc60775",
+        "linux/amd64": "https://github.com/burnt-labs/xion/releases/download/v22.0.0/xiond_22.0.0_linux_amd64.tar.gz?checksum=sha256:ff7fa1dd1032d62c84e74daa3d621bfd66004f3c00da9dcd09da78cff9942310",
+        "linux/arm64": "https://github.com/burnt-labs/xion/releases/download/v22.0.0/xiond_22.0.0_linux_arm64.tar.gz?checksum=sha256:943350a554472fac3875e11e2ed26a8db5c96314f394985d134ec789094b9a23"
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "v0.53.4"
+      },
+      "consensus": {
+        "type": "cometbft",
+        "version": "v0.38.19"
+      },
+      "cosmwasm": {
+        "version": "v0.61.6",
+        "enabled": true
+      },
+      "ibc": {
+        "type": "go",
+        "version": "v10.4.0"
+      }
+    },
+    {
+      "name": "v23",
+      "tag": "v23.0.0",
+      "recommended_version": "v23.0.0",
+      "height": 9431000,
+      "proposal": 44,
+      "language": {
+        "type": "go",
+        "version": "v1.25"
+      },
+      "binaries": {
+        "darwin/amd64": "https://github.com/burnt-labs/xion/releases/download/v23.0.0/xiond_23.0.0_darwin_amd64.tar.gz?checksum=sha256:7f16f2212abb5eb1720e7239f287b9d1fe3ec6e919a895aa01b07ea5e340f448",
+        "darwin/arm64": "https://github.com/burnt-labs/xion/releases/download/v23.0.0/xiond_23.0.0_darwin_arm64.tar.gz?checksum=sha256:8c928c5916a315652106ac8eabde4a32193cde6a61f71a959302b1c6b713de6c",
+        "linux/amd64": "https://github.com/burnt-labs/xion/releases/download/v23.0.0/xiond_23.0.0_linux_amd64.tar.gz?checksum=sha256:85f21c514d9f677c58b37e988923de9b47fdfb6746e97cc6c72f18e47363531a",
+        "linux/arm64": "https://github.com/burnt-labs/xion/releases/download/v23.0.0/xiond_23.0.0_linux_arm64.tar.gz?checksum=sha256:d4373c1981a8637a49d904b6fb2a32bd2c696ec59edcbdade2b70ecf197ac937"
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "v0.53.4"
+      },
+      "consensus": {
+        "type": "cometbft",
+        "version": "v0.38.19"
+      },
+      "cosmwasm": {
+        "version": "v0.61.6",
+        "enabled": true
+      },
+      "ibc": {
+        "type": "go",
+        "version": "v10.4.0"
+      }
+    },
+    {
+      "name": "v24",
+      "tag": "v24.0.0",
+      "recommended_version": "v24.0.0",
+      "height": 9500000,
+      "proposal": 45,
+      "language": {
+        "type": "go",
+        "version": "v1.25"
+      },
+      "binaries": {
+        "darwin/amd64": "https://github.com/burnt-labs/xion/releases/download/v24.0.0/xiond_24.0.0_darwin_amd64.tar.gz?checksum=sha256:a14623faa9c44a1ec219b279455d86aada9242f2f10fb7ee76eddf0e9f88ac12",
+        "darwin/arm64": "https://github.com/burnt-labs/xion/releases/download/v24.0.0/xiond_24.0.0_darwin_arm64.tar.gz?checksum=sha256:9b6a4ac4f39e03894ed78e422a985729d4ec4347d4761d370f06fa7bdc8824ae",
+        "linux/amd64": "https://github.com/burnt-labs/xion/releases/download/v24.0.0/xiond_24.0.0_linux_amd64.tar.gz?checksum=sha256:f8c4328551f6281b2a5382faf6d94ab4d6da05fd7f99f7f06e2a25732739e9f8",
+        "linux/arm64": "https://github.com/burnt-labs/xion/releases/download/v24.0.0/xiond_24.0.0_linux_arm64.tar.gz?checksum=sha256:5250ced813211527292ac5be621c5ab0c89701838e27935652fa1367ae910487"
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "v0.53.4"
+      },
+      "consensus": {
+        "type": "cometbft",
+        "version": "v0.38.19"
+      },
+      "cosmwasm": {
+        "version": "v0.61.6",
+        "enabled": true
+      },
+      "ibc": {
+        "type": "go",
+        "version": "v10.4.0"
+      }
+    },
+    {
+      "name": "v25",
+      "tag": "v25.0.2",
+      "recommended_version": "v25.0.2",
+      "height": 9542000,
+      "proposal": 46,
+      "language": {
+        "type": "go",
+        "version": "v1.25"
+      },
+      "binaries": {
+        "darwin/amd64": "https://github.com/burnt-labs/xion/releases/download/v25.0.2/xiond_25.0.2_darwin_amd64.tar.gz?checksum=sha256:5c6f73c6945705755dd91342df620dc67ef897940bbdabf00d570e06666cceab",
+        "darwin/arm64": "https://github.com/burnt-labs/xion/releases/download/v25.0.2/xiond_25.0.2_darwin_arm64.tar.gz?checksum=sha256:b1485593c112162b28aa4ed2b6174a535408b7f2557d8fcb7838fbdfc03d6a9f",
+        "linux/amd64": "https://github.com/burnt-labs/xion/releases/download/v25.0.2/xiond_25.0.2_linux_amd64.tar.gz?checksum=sha256:4992be2389c783d8a724f4f6b405a89b5572b33ab5767473262d1c780f57fb15",
+        "linux/arm64": "https://github.com/burnt-labs/xion/releases/download/v25.0.2/xiond_25.0.2_linux_arm64.tar.gz?checksum=sha256:566e90bd69369e1d9fec26e95e8497e7d00176844745db95497ddadf4991f169"
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "v0.53.4"
+      },
+      "consensus": {
+        "type": "cometbft",
+        "version": "v0.38.19"
+      },
+      "cosmwasm": {
+        "version": "v0.61.6",
+        "enabled": true
+      },
+      "ibc": {
+        "type": "go",
+        "version": "v10.4.0"
+      }
+    },
+    {
+      "name": "v26",
+      "tag": "v26.1.0-rc3",
+      "recommended_version": "v26.1.0-rc3",
+      "compatible_versions": [
+        "v26.1.0-rc3"
+      ],
+      "height": 11725000,
+      "proposal": 48,
+      "language": {
+        "type": "go",
+        "version": "v1.25"
+      },
+      "binaries": {
+        "darwin/amd64": "https://github.com/burnt-labs/xion/releases/download/v26.1.0-rc3/xiond_26.1.0-rc3_darwin_amd64.tar.gz",
+        "darwin/arm64": "https://github.com/burnt-labs/xion/releases/download/v26.1.0-rc3/xiond_26.1.0-rc3_darwin_arm64.tar.gz",
+        "linux/amd64": "https://github.com/burnt-labs/xion/releases/download/v26.1.0-rc3/xiond_26.1.0-rc3_linux_amd64.tar.gz",
+        "linux/arm64": "https://github.com/burnt-labs/xion/releases/download/v26.1.0-rc3/xiond_26.1.0-rc3_linux_arm64.tar.gz"
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "v0.53.4"
+      },
+      "consensus": {
+        "type": "cometbft",
+        "version": "v0.38.21"
+      },
+      "cosmwasm": {
+        "version": "v0.61.6",
+        "enabled": true
+      },
+      "ibc": {
+        "type": "go",
+        "version": "v10.4.0"
+      }
+    },
+    {
+      "name": "v27",
+      "tag": "v27.0.0-rc2",
+      "recommended_version": "v27.0.0-rc2",
+      "compatible_versions": [
+        "v27.0.0-rc2"
+      ],
+      "height": 12450000,
+      "proposal": 51,
+      "language": {
+        "type": "go",
+        "version": "v1.25"
+      },
+      "binaries": {
+        "darwin/amd64": "https://github.com/burnt-labs/xion/releases/download/v27.0.0-rc2/xiond_27.0.0-rc2_darwin_amd64.tar.gz?checksum=sha256:4d7baaafa1497cd7cebf4d89e5404aa0db7bd6e190cc41a7349e97c2efda9abf",
+        "darwin/arm64": "https://github.com/burnt-labs/xion/releases/download/v27.0.0-rc2/xiond_27.0.0-rc2_darwin_arm64.tar.gz?checksum=sha256:126142075c21bd98a7f2599b30ff42620d10743f09957538422992b9551baeec",
+        "linux/amd64": "https://github.com/burnt-labs/xion/releases/download/v27.0.0-rc2/xiond_27.0.0-rc2_linux_amd64.tar.gz?checksum=sha256:157f0afa84c73247373f97047debe24cb768181dc8214d4da16204662e715ffe",
+        "linux/arm64": "https://github.com/burnt-labs/xion/releases/download/v27.0.0-rc2/xiond_27.0.0-rc2_linux_arm64.tar.gz?checksum=sha256:336705c16d327aa34df4e5a60f9f9d9c74ff40a997fa8087ca97d438b4934537"
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "v0.53.4"
+      },
+      "consensus": {
+        "type": "cometbft",
+        "version": "v0.38.21"
+      },
+      "cosmwasm": {
+        "version": "v0.61.6",
+        "enabled": true
+      },
+      "ibc": {
+        "type": "go",
+        "version": "v10.4.0"
+      }
+    },
+    {
+      "name": "v28",
+      "tag": "v28.1.0",
+      "recommended_version": "v28.1.0",
+      "compatible_versions": [
+        "v28.1.0"
+      ],
+      "language": {
+        "type": "go",
+        "version": "v1.25"
+      },
+      "binaries": {
+        "darwin/amd64": "https://github.com/burnt-labs/xion/releases/download/v28.1.0/xiond_28.1.0_darwin_amd64.tar.gz?checksum=sha256:e71ae26b7234746232e03f58bfa384ff3a8d6bcc7bba7e1bb12a8f49d563b81b",
+        "darwin/arm64": "https://github.com/burnt-labs/xion/releases/download/v28.1.0/xiond_28.1.0_darwin_arm64.tar.gz?checksum=sha256:dc5d69ea497ea6187e85d5952a2aed29687b9accddb23c993ae92da25e7df7d3",
+        "linux/amd64": "https://github.com/burnt-labs/xion/releases/download/v28.1.0/xiond_28.1.0_linux_amd64.tar.gz?checksum=sha256:9e69770f5d70979f6574ef466e5a39022f8ced73b6376913501d44f8d82f7454",
+        "linux/arm64": "https://github.com/burnt-labs/xion/releases/download/v28.1.0/xiond_28.1.0_linux_arm64.tar.gz?checksum=sha256:a2a1ee3be6b23d51c86988ba42b307f60c80a15f4aac6b5d6adf46ef421f3519"
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "v0.53.6"
+      },
+      "consensus": {
+        "type": "cometbft",
+        "version": "v0.38.21"
+      },
+      "cosmwasm": {
+        "version": "v0.61.8",
+        "enabled": true
+      },
+      "ibc": {
+        "type": "go",
+        "version": "v10.5.0"
+      },
+      "height": 12823000,
+      "proposal": 57
+    },
+    {
+      "name": "v29",
+      "tag": "v29.0.0-rc1",
+      "recommended_version": "v29.0.0-rc1",
+      "compatible_versions": [
+        "v29.0.0-rc1"
+      ],
+      "height": 14235000,
+      "proposal": 58,
+      "language": {
+        "type": "go",
+        "version": "v1.25"
+      },
+      "binaries": {
+        "darwin/amd64": "https://github.com/burnt-labs/xion/releases/download/v29.0.0-rc1/xiond_29.0.0-rc1_darwin_amd64.tar.gz?checksum=sha256:52fb0e7bb4c65a2170b8eb2ae94d9489251014ab33379569437802b15b5dc6ff",
+        "darwin/arm64": "https://github.com/burnt-labs/xion/releases/download/v29.0.0-rc1/xiond_29.0.0-rc1_darwin_arm64.tar.gz?checksum=sha256:6865a82aa1b8a7b4245fbe4d98e227d6561d9c372472f4d9b09dcadd20c25948",
+        "linux/amd64": "https://github.com/burnt-labs/xion/releases/download/v29.0.0-rc1/xiond_29.0.0-rc1_linux_amd64.tar.gz?checksum=sha256:63f2a48d8664acb3db1d12a11780da36537575c4e8678fb2e0ab6c0a64dfa4af",
+        "linux/arm64": "https://github.com/burnt-labs/xion/releases/download/v29.0.0-rc1/xiond_29.0.0-rc1_linux_arm64.tar.gz?checksum=sha256:76cfb7f8356e0feb111d3b4feeaef7cdf10ff95cc9b7a28329660a3a92051e41"
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "v0.53.6"
+      },
+      "consensus": {
+        "type": "cometbft",
+        "version": "v0.38.21"
+      },
+      "cosmwasm": {
+        "version": "v0.61.10",
+        "enabled": true
+      },
+      "ibc": {
+        "type": "go",
+        "version": "v10.5.0"
+      }
     }
   ]
 }

--- a/xion/chain.json
+++ b/xion/chain.json
@@ -42,39 +42,39 @@
   },
   "codebase": {
     "git_repo": "https://github.com/burnt-labs/xion",
-    "tag": "v25.0.1",
-    "recommended_version": "v25.0.1",
+    "tag": "v28.1.0",
+    "recommended_version": "v28.1.0",
     "language": {
       "type": "go",
       "version": "v1.25"
     },
     "binaries": {
-      "darwin/amd64": "https://github.com/burnt-labs/xion/releases/download/v25.0.1/xiond_25.0.1_darwin_amd64.tar.gz?checksum=sha256:dbfafeb540cdecf913d81b649371915a399c6805a7a41b74369f339d2190c41c",
-      "darwin/arm64": "https://github.com/burnt-labs/xion/releases/download/v25.0.1/xiond_25.0.1_darwin_arm64.tar.gz?checksum=sha256:4417bc803aa11aa5cb84f641da93b32f29b634e751923a6e288b1676faeed97f",
-      "linux/amd64": "https://github.com/burnt-labs/xion/releases/download/v25.0.1/xiond_25.0.1_linux_amd64.tar.gz?checksum=sha256:739f4d1aa5b4ffdcdbb761b4d0a2601cdbe916126423f3ea2f8044f2403c864d",
-      "linux/arm64": "https://github.com/burnt-labs/xion/releases/download/v25.0.1/xiond_25.0.1_linux_arm64.tar.gz?checksum=sha256:c24c8d68828850d12e36e8fb917f3cccd6d9ae28050380e6f163039790b87016"
+      "darwin/amd64": "https://github.com/burnt-labs/xion/releases/download/v28.1.0/xiond_28.1.0_darwin_amd64.tar.gz?checksum=sha256:e71ae26b7234746232e03f58bfa384ff3a8d6bcc7bba7e1bb12a8f49d563b81b",
+      "darwin/arm64": "https://github.com/burnt-labs/xion/releases/download/v28.1.0/xiond_28.1.0_darwin_arm64.tar.gz?checksum=sha256:dc5d69ea497ea6187e85d5952a2aed29687b9accddb23c993ae92da25e7df7d3",
+      "linux/amd64": "https://github.com/burnt-labs/xion/releases/download/v28.1.0/xiond_28.1.0_linux_amd64.tar.gz?checksum=sha256:9e69770f5d70979f6574ef466e5a39022f8ced73b6376913501d44f8d82f7454",
+      "linux/arm64": "https://github.com/burnt-labs/xion/releases/download/v28.1.0/xiond_28.1.0_linux_arm64.tar.gz?checksum=sha256:a2a1ee3be6b23d51c86988ba42b307f60c80a15f4aac6b5d6adf46ef421f3519"
     },
     "sdk": {
       "type": "cosmos",
-      "version": "v0.53.4"
+      "version": "v0.53.6"
     },
     "consensus": {
       "type": "cometbft",
-      "version": "v0.38.19"
+      "version": "v0.38.21"
     },
     "cosmwasm": {
-      "version": "v0.61.6",
+      "version": "v0.61.8",
       "enabled": true
     },
     "ibc": {
       "type": "go",
-      "version": "v10.4.0"
+      "version": "v10.5.0"
     },
     "genesis": {
       "genesis_url": "https://raw.githubusercontent.com/burnt-labs/xion-mainnet-1/main/config/genesis.json"
     },
     "compatible_versions": [
-      "v25.0.1"
+      "v28.1.0"
     ]
   },
   "peers": {
@@ -82,12 +82,12 @@
       {
         "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
         "address": "xion-mainnet-seed.autostake.com:27596",
-        "provider": "AutoStake 🛡️ Slash Protected"
+        "provider": "AutoStake \ud83d\udee1\ufe0f Slash Protected"
       },
       {
         "id": "20e1000e88125698264454a884812746c2eb4807",
         "address": "seeds.lavenderfive.com:22356",
-        "provider": "Lavender.Five Nodes 🐝"
+        "provider": "Lavender.Five Nodes \ud83d\udc1d"
       },
       {
         "id": "ade4d8bc8cbe014af6ebdf3cb7b1e9ad36f412c0",
@@ -99,12 +99,12 @@
       {
         "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
         "address": "xion-mainnet-peer.autostake.com:27596",
-        "provider": "AutoStake 🛡️ Slash Protected"
+        "provider": "AutoStake \ud83d\udee1\ufe0f Slash Protected"
       },
       {
         "id": "20e1000e88125698264454a884812746c2eb4807",
         "address": "seeds.lavenderfive.com:22356",
-        "provider": "Lavender.Five Nodes 🐝"
+        "provider": "Lavender.Five Nodes \ud83d\udc1d"
       },
       {
         "id": "cc90aceb84a07b2bd4fe1dce3c1542a3900cf2f8",
@@ -142,11 +142,11 @@
     "rpc": [
       {
         "address": "https://rpc.xion-mainnet-1.burnt.com:443",
-        "provider": "🔥BurntLabs🔥"
+        "provider": "\ud83d\udd25BurntLabs\ud83d\udd25"
       },
       {
         "address": "https://xion-rpc.lavenderfive.com:443",
-        "provider": "Lavender.Five Nodes 🐝"
+        "provider": "Lavender.Five Nodes \ud83d\udc1d"
       },
       {
         "address": "https://rpc-burnt.imperator.co:443",
@@ -158,7 +158,7 @@
       },
       {
         "address": "https://xion-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
+        "provider": "AutoStake \ud83d\udee1\ufe0f Slash Protected"
       },
       {
         "address": "https://rpc.xion.nodestake.org:443",
@@ -166,17 +166,17 @@
       },
       {
         "address": "https://xion-rpc.kingnodes.com:443",
-        "provider": "kingnodes 👑"
+        "provider": "kingnodes \ud83d\udc51"
       }
     ],
     "rest": [
       {
         "address": "https://api.xion-mainnet-1.burnt.com",
-        "provider": "🔥BurntLabs🔥"
+        "provider": "\ud83d\udd25BurntLabs\ud83d\udd25"
       },
       {
         "address": "https://xion-api.lavenderfive.com",
-        "provider": "Lavender.Five Nodes 🐝"
+        "provider": "Lavender.Five Nodes \ud83d\udc1d"
       },
       {
         "address": "https://lcd-burnt.imperator.co",
@@ -188,7 +188,7 @@
       },
       {
         "address": "https://xion-mainnet-lcd.autostake.com",
-        "provider": "AutoStake 🛡️ Slash Protected"
+        "provider": "AutoStake \ud83d\udee1\ufe0f Slash Protected"
       },
       {
         "address": "https://api.xion.nodestake.org",
@@ -196,17 +196,17 @@
       },
       {
         "address": "https://xion-rest.kingnodes.com",
-        "provider": "kingnodes 👑"
+        "provider": "kingnodes \ud83d\udc51"
       }
     ],
     "grpc": [
       {
         "address": "grpc.xion-mainnet-1.burnt.com:443",
-        "provider": "🔥BurntLabs🔥"
+        "provider": "\ud83d\udd25BurntLabs\ud83d\udd25"
       },
       {
         "address": "xion-grpc.lavenderfive.com:443",
-        "provider": "Lavender.Five Nodes 🐝"
+        "provider": "Lavender.Five Nodes \ud83d\udc1d"
       },
       {
         "address": "xion-grpc.polkachu.com:22390",
@@ -214,7 +214,7 @@
       },
       {
         "address": "xion-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake 🛡️ Slash Protected"
+        "provider": "AutoStake \ud83d\udee1\ufe0f Slash Protected"
       },
       {
         "address": "grpc.xion.nodestake.org:443",
@@ -222,7 +222,7 @@
       },
       {
         "address": "xion-grpc.kingnodes.com:443",
-        "provider": "kingnodes 👑"
+        "provider": "kingnodes \ud83d\udc51"
       }
     ]
   },

--- a/xion/chain.json
+++ b/xion/chain.json
@@ -80,11 +80,6 @@
   "peers": {
     "seeds": [
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "xion-mainnet-seed.autostake.com:27596",
-        "provider": "AutoStake \ud83d\udee1\ufe0f Slash Protected"
-      },
-      {
         "id": "20e1000e88125698264454a884812746c2eb4807",
         "address": "seeds.lavenderfive.com:22356",
         "provider": "Lavender.Five Nodes \ud83d\udc1d"
@@ -102,24 +97,9 @@
     ],
     "persistent_peers": [
       {
-        "id": "ebc272824924ea1a27ea3183dd0b9ba713494f83",
-        "address": "xion-mainnet-peer.autostake.com:27596",
-        "provider": "AutoStake \ud83d\udee1\ufe0f Slash Protected"
-      },
-      {
-        "id": "20e1000e88125698264454a884812746c2eb4807",
-        "address": "seeds.lavenderfive.com:22356",
-        "provider": "Lavender.Five Nodes \ud83d\udc1d"
-      },
-      {
         "id": "cc90aceb84a07b2bd4fe1dce3c1542a3900cf2f8",
         "address": "65.109.122.90:26656",
         "provider": "Blockval"
-      },
-      {
-        "id": "d27cde0c62024a05d46fe375cb91956584fa69a4",
-        "address": "15.235.115.151:18400",
-        "provider": "Cosmostation"
       },
       {
         "id": "c36b658e1e2725542faa14063bfe4f9659286406",
@@ -130,16 +110,6 @@
         "id": "7419137b70620c358cdf38809f1c00eba17cd420",
         "address": "72.251.3.24:56206",
         "provider": "Nodes.Guru"
-      },
-      {
-        "id": "5f5cfac5c38506fbb4275c19e87c4107ec48808d",
-        "address": "65.21.198.100:12956",
-        "provider": "nodex.one"
-      },
-      {
-        "id": "766af9cd08365704f7962d3071d1a9c684a88005",
-        "address": "95.217.224.124:43656",
-        "provider": "stakeLab"
       },
       {
         "id": "7b689a51064007d0da05384b1ae6037dca9aae85",
@@ -155,28 +125,12 @@
         "provider": "\ud83d\udd25BurntLabs\ud83d\udd25"
       },
       {
-        "address": "https://xion-rpc.lavenderfive.com:443",
-        "provider": "Lavender.Five Nodes \ud83d\udc1d"
-      },
-      {
         "address": "https://rpc-burnt.imperator.co:443",
         "provider": "Imperator.co"
       },
       {
         "address": "https://xion-rpc.polkachu.com:443",
         "provider": "Polkachu"
-      },
-      {
-        "address": "https://xion-mainnet-rpc.autostake.com:443",
-        "provider": "AutoStake \ud83d\udee1\ufe0f Slash Protected"
-      },
-      {
-        "address": "https://rpc.xion.nodestake.org:443",
-        "provider": "NodeStake"
-      },
-      {
-        "address": "https://xion-rpc.kingnodes.com:443",
-        "provider": "kingnodes \ud83d\udc51"
       },
       {
         "address": "https://xion-mainnet-rpc.itrocket.net:443",
@@ -189,28 +143,12 @@
         "provider": "\ud83d\udd25BurntLabs\ud83d\udd25"
       },
       {
-        "address": "https://xion-api.lavenderfive.com",
-        "provider": "Lavender.Five Nodes \ud83d\udc1d"
-      },
-      {
         "address": "https://lcd-burnt.imperator.co",
         "provider": "Imperator.co"
       },
       {
         "address": "https://xion-api.polkachu.com",
         "provider": "Polkachu"
-      },
-      {
-        "address": "https://xion-mainnet-lcd.autostake.com",
-        "provider": "AutoStake \ud83d\udee1\ufe0f Slash Protected"
-      },
-      {
-        "address": "https://api.xion.nodestake.org",
-        "provider": "NodeStake"
-      },
-      {
-        "address": "https://xion-rest.kingnodes.com",
-        "provider": "kingnodes \ud83d\udc51"
       },
       {
         "address": "https://xion-mainnet-api.itrocket.net",
@@ -223,24 +161,8 @@
         "provider": "\ud83d\udd25BurntLabs\ud83d\udd25"
       },
       {
-        "address": "xion-grpc.lavenderfive.com:443",
-        "provider": "Lavender.Five Nodes \ud83d\udc1d"
-      },
-      {
         "address": "xion-grpc.polkachu.com:22390",
         "provider": "Polkachu"
-      },
-      {
-        "address": "xion-mainnet-grpc.autostake.com:443",
-        "provider": "AutoStake \ud83d\udee1\ufe0f Slash Protected"
-      },
-      {
-        "address": "grpc.xion.nodestake.org:443",
-        "provider": "NodeStake"
-      },
-      {
-        "address": "xion-grpc.kingnodes.com:443",
-        "provider": "kingnodes \ud83d\udc51"
       },
       {
         "address": "xion-mainnet-grpc.itrocket.net:443",
@@ -266,12 +188,6 @@
       "url": "https://staking-explorer.com/explorer/xion",
       "tx_page": "https://staking-explorer.com/transaction.php?chain=xion&tx=${txHash}",
       "account_page": "https://staking-explorer.com/account.php?chain=xion&addr=${accountAddress}"
-    },
-    {
-      "kind": "NodeStake",
-      "url": "https://explorer.nodestake.org/xion",
-      "tx_page": "https://explorer.nodestake.org/xion/tx/${txHash}",
-      "account_page": "https://explorer.nodestake.org/xion/account/${accountAddress}"
     },
     {
       "kind": "Nodes.Guru",

--- a/xion/chain.json
+++ b/xion/chain.json
@@ -93,6 +93,11 @@
         "id": "ade4d8bc8cbe014af6ebdf3cb7b1e9ad36f412c0",
         "address": "seeds.polkachu.com:22356",
         "provider": "Polkachu"
+      },
+      {
+        "id": "e4bd1c9ec11cdceb438a16bdc7c49e4d4ebbfbce",
+        "address": "xion-mainnet-seed.itrocket.net:24656",
+        "provider": "ITRocket"
       }
     ],
     "persistent_peers": [
@@ -135,6 +140,11 @@
         "id": "766af9cd08365704f7962d3071d1a9c684a88005",
         "address": "95.217.224.124:43656",
         "provider": "stakeLab"
+      },
+      {
+        "id": "7b689a51064007d0da05384b1ae6037dca9aae85",
+        "address": "xion-mainnet-peer.itrocket.net:24656",
+        "provider": "ITRocket"
       }
     ]
   },
@@ -167,6 +177,10 @@
       {
         "address": "https://xion-rpc.kingnodes.com:443",
         "provider": "kingnodes \ud83d\udc51"
+      },
+      {
+        "address": "https://xion-mainnet-rpc.itrocket.net:443",
+        "provider": "ITRocket"
       }
     ],
     "rest": [
@@ -197,6 +211,10 @@
       {
         "address": "https://xion-rest.kingnodes.com",
         "provider": "kingnodes \ud83d\udc51"
+      },
+      {
+        "address": "https://xion-mainnet-api.itrocket.net",
+        "provider": "ITRocket"
       }
     ],
     "grpc": [
@@ -223,6 +241,10 @@
       {
         "address": "xion-grpc.kingnodes.com:443",
         "provider": "kingnodes \ud83d\udc51"
+      },
+      {
+        "address": "xion-mainnet-grpc.itrocket.net:443",
+        "provider": "ITRocket"
       }
     ]
   },
@@ -256,6 +278,12 @@
       "url": "https://xion.explorers.guru",
       "tx_page": "https://xion.explorers.guru/transactions/${txHash}",
       "account_page": "https://xion.explorers.guru//account/${accountAddress}"
+    },
+    {
+      "kind": "ITRocket",
+      "url": "https://mainnet.itrocket.net/xion",
+      "tx_page": "https://mainnet.itrocket.net/xion/tx/${txHash}",
+      "account_page": "https://mainnet.itrocket.net/xion/account/${accountAddress}"
     }
   ],
   "images": [

--- a/xion/versions.json
+++ b/xion/versions.json
@@ -481,6 +481,42 @@
         "type": "go",
         "version": "v10.4.0"
       }
+    },
+    {
+      "name": "v28",
+      "tag": "v28.1.0",
+      "recommended_version": "v28.1.0",
+      "compatible_versions": [
+        "v28.1.0"
+      ],
+      "height": 18912000,
+      "proposal": 54,
+      "language": {
+        "type": "go",
+        "version": "v1.25"
+      },
+      "binaries": {
+        "darwin/amd64": "https://github.com/burnt-labs/xion/releases/download/v28.1.0/xiond_28.1.0_darwin_amd64.tar.gz?checksum=sha256:e71ae26b7234746232e03f58bfa384ff3a8d6bcc7bba7e1bb12a8f49d563b81b",
+        "darwin/arm64": "https://github.com/burnt-labs/xion/releases/download/v28.1.0/xiond_28.1.0_darwin_arm64.tar.gz?checksum=sha256:dc5d69ea497ea6187e85d5952a2aed29687b9accddb23c993ae92da25e7df7d3",
+        "linux/amd64": "https://github.com/burnt-labs/xion/releases/download/v28.1.0/xiond_28.1.0_linux_amd64.tar.gz?checksum=sha256:9e69770f5d70979f6574ef466e5a39022f8ced73b6376913501d44f8d82f7454",
+        "linux/arm64": "https://github.com/burnt-labs/xion/releases/download/v28.1.0/xiond_28.1.0_linux_arm64.tar.gz?checksum=sha256:a2a1ee3be6b23d51c86988ba42b307f60c80a15f4aac6b5d6adf46ef421f3519"
+      },
+      "sdk": {
+        "type": "cosmos",
+        "version": "v0.53.6"
+      },
+      "consensus": {
+        "type": "cometbft",
+        "version": "v0.38.21"
+      },
+      "cosmwasm": {
+        "version": "v0.61.8",
+        "enabled": true
+      },
+      "ibc": {
+        "type": "go",
+        "version": "v10.5.0"
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Add testnet versions v21-v29 (were lost in upstream cosmos/chain-registry sync after PR #13 merge)
- Fix testnet v19 incorrect height (was 7420000, correct is 4050000) and proposal (was 37, correct is 23)
- Add mainnet v28 entry (height 18912000, proposal 54)
- Update mainnet chain.json codebase to v28.1.0
- Update testnet chain.json codebase to v29.0.0-rc1

## Context
PR #13 was merged but then overwritten by an upstream sync from cosmos/chain-registry. This re-applies those changes plus fixes existing data errors.

## Test plan
- [ ] Verify all testnet version heights match on-chain data
- [ ] Verify mainnet v28 entry matches on-chain data

🤖 Generated with [Claude Code](https://claude.com/claude-code)